### PR TITLE
Precise version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ drf-haystack==1.5.6
 elasticsearch==2.3.0
 elasticstack==0.1.1
 django-polymorphic==0.9.2
-django-categories==1.3
+django-categories==1.3b8
 django-pagedown==0.1.0


### PR DESCRIPTION
Bugs in tastypie : Module specify version in requirements
-e git+https://github.com/django-* will be ==x.x.x

