### PR TITLE
Test api v2

### DIFF
--- a/assets/tests/test_api_v2.py
+++ b/assets/tests/test_api_v2.py
@@ -1,0 +1,40 @@
+import pytest
+
+from people.tests.conftest import *  # noqa
+from utils.tests.utils import (
+    IsArtistOrReadOnlyModelViewSetMixin,
+    HelpTestForModelViewSet,
+    parametrize_user_roles,
+)
+
+
+def pytest_generate_tests(metafunc):
+    # pytest hook; called once per each test function
+    parametrize_user_roles(metafunc)
+
+
+@pytest.mark.django_db
+class TestMediumViewSet(IsArtistOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'assets/medium'
+
+    fixtures = ['medium', 'artist', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['medium_url', 'gallery']
+
+    mutate_fields = ['label']
+    put_fields = ['gallery']
+    hyperlinked_fields = {'gallery': 'gallery'}
+
+
+@pytest.mark.django_db
+class TestGalleryViewSet(IsArtistOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'assets/gallery'
+
+    fixtures = ['gallery', 'artist', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['media', 'url']
+
+    mutate_fields = ['label']
+    put_fields = ['label', 'description']

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -23,7 +23,7 @@ class TestVimeoUploadToken:
             jwt = obtain_jwt_token(user)
             if user_role == 'old_user':
                 user.delete()
-            response = client.get(url, HTTP_AUTHORIZATION='Bearer {}'.format(jwt['token']))
+            response = client.get(url, HTTP_AUTHORIZATION='JWT {}'.format(jwt['token']))
         else:
             response = client.get(url)
 

--- a/assets/views.py
+++ b/assets/views.py
@@ -28,6 +28,8 @@ def vimeo_get_upload_token(request):
 
     # make sur user is auth
     if(request.META.get('HTTP_AUTHORIZATION')):
+        # FIXME: on devrait filtrer la méthode d'autorisation
+        # et intercepter une exception de décodage
         token = request.META['HTTP_AUTHORIZATION'].split(' ')[1]
         jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
         infos = jwt_decode_handler(token)

--- a/common/tests/test_api_v2.py
+++ b/common/tests/test_api_v2.py
@@ -1,5 +1,7 @@
 import pytest
 
+from uuid import uuid4
+
 from common.tests.conftest import *  # noqa
 from diffusion.tests.conftest import *  # noqa
 from production.tests.conftest import *  # noqa
@@ -26,6 +28,7 @@ class TestBTBeaconViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestFo
 
     mutate_fields = ['rssi_in']
     put_fields = ['rssi_in', 'rssi_out', 'uuid', 'x', 'y', 'label']
+    built_fields = {'uuid': lambda x: str(uuid4())}
 
     def target(self):
         return self.btbeacon

--- a/common/tests/test_api_v2.py
+++ b/common/tests/test_api_v2.py
@@ -30,9 +30,6 @@ class TestBTBeaconViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestFo
     put_fields = ['rssi_in', 'rssi_out', 'uuid', 'x', 'y', 'label']
     built_fields = {'uuid': lambda x: str(uuid4())}
 
-    def target(self):
-        return self.btbeacon
-
 
 @pytest.mark.django_db
 class TestWebsiteViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
@@ -47,6 +44,3 @@ class TestWebsiteViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestFor
     put_fields = ['link', 'language', 'title_fr', 'title_en']
     hyperlinked_fields = {'url': 'website'}
     renamed_fields = {'link': 'url'}
-
-    def target(self):
-        return self.website

--- a/common/tests/test_api_v2.py
+++ b/common/tests/test_api_v2.py
@@ -1,0 +1,55 @@
+import pytest
+
+from common.tests.conftest import *  # noqa
+from diffusion.tests.conftest import *  # noqa
+from production.tests.conftest import *  # noqa
+from utils.tests.utils import (
+    IsAuthenticatedOrReadOnlyModelViewSetMixin,
+    HelpTestForModelViewSet,
+    parametrize_user_roles,
+)
+
+
+def pytest_generate_tests(metafunc):
+    # pytest hook; called once per each test function
+    parametrize_user_roles(metafunc)
+
+
+@pytest.mark.django_db
+class TestBTBeaconViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'common/beacon'
+
+    fixtures = ['btbeacon', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['rssi_in', 'rssi_out']
+
+    mutate_fields = ['rssi_in']
+    put_fields = ['rssi_in', 'rssi_out', 'uuid', 'x', 'y', 'label']
+
+    def target(self):
+        return self.btbeacon
+
+    def requestor(self):
+        return self.user
+
+
+@pytest.mark.django_db
+class TestWebsiteViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'common/website'
+
+    fixtures = ['website', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['url', 'link', 'language', 'title_fr', 'title_en']
+
+    mutate_fields = ['title_fr']
+    put_fields = ['link', 'language', 'title_fr', 'title_en']
+    hyperlinked_fields = {'url': 'website'}
+    renamed_fields = {'link': 'url'}
+
+    def target(self):
+        return self.website
+
+    def requestor(self):
+        return self.user

--- a/common/tests/test_api_v2.py
+++ b/common/tests/test_api_v2.py
@@ -33,9 +33,6 @@ class TestBTBeaconViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestFo
     def target(self):
         return self.btbeacon
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestWebsiteViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
@@ -53,6 +50,3 @@ class TestWebsiteViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestFor
 
     def target(self):
         return self.website
-
-    def requestor(self):
-        return self.user

--- a/diffusion/tests/factories.py
+++ b/diffusion/tests/factories.py
@@ -50,6 +50,7 @@ class MetaEventFactory(factory.django.DjangoModelFactory):
         model = models.MetaEvent
 
     event = factory.SubFactory(EventFactory, main_event=True)
+    genres = factory.fuzzy.FuzzyChoice(models.MetaEvent.GENRES_CHOICES, getter=first)
 
 
 class DiffusionFactory(factory.django.DjangoModelFactory):

--- a/diffusion/tests/test_api.py
+++ b/diffusion/tests/test_api.py
@@ -24,9 +24,6 @@ class TestPlaceRessource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.place
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestAwardRessource(HelpTestForReadOnlyModelRessource):
@@ -40,7 +37,7 @@ class TestAwardRessource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.award
 
-    def requestor(self):
+    def requestor(self, role):
         return self.artist.user
 
 
@@ -55,6 +52,3 @@ class TestMetaAwardRessource(HelpTestForReadOnlyModelRessource):
 
     def target(self):
         return self.meta_award
-
-    def requestor(self):
-        return self.user

--- a/diffusion/tests/test_api.py
+++ b/diffusion/tests/test_api.py
@@ -14,7 +14,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.mark.django_db
 class TestPlaceRessource(HelpTestForReadOnlyModelRessource):
-    model = api.PlaceResource
+    resource = api.PlaceResource
 
     fixtures = ['user', 'place']
 
@@ -30,7 +30,7 @@ class TestPlaceRessource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestAwardRessource(HelpTestForReadOnlyModelRessource):
-    model = api.AwardResource
+    resource = api.AwardResource
 
     fixtures = ['award', 'artist', 'artwork']
 
@@ -46,7 +46,7 @@ class TestAwardRessource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestMetaAwardRessource(HelpTestForReadOnlyModelRessource):
-    model = api.MetaAwardResource
+    resource = api.MetaAwardResource
 
     fixtures = ['meta_award', 'user']
 

--- a/diffusion/tests/test_api.py
+++ b/diffusion/tests/test_api.py
@@ -16,13 +16,10 @@ def pytest_generate_tests(metafunc):
 class TestPlaceRessource(HelpTestForReadOnlyModelRessource):
     resource = api.PlaceResource
 
-    fixtures = ['user', 'place']
+    fixtures = ['place', 'user']
 
     expected_list_size = 1
     expected_fields = ['name', 'latitude', 'longitude']
-
-    def target(self):
-        return self.place
 
 
 @pytest.mark.django_db
@@ -33,9 +30,6 @@ class TestAwardRessource(HelpTestForReadOnlyModelRessource):
 
     expected_list_size = 1
     expected_fields = ['date', 'meta_award', 'artwork', 'artist']
-
-    def target(self):
-        return self.award
 
     def requestor(self, role):
         return self.artist.user
@@ -49,6 +43,3 @@ class TestMetaAwardRessource(HelpTestForReadOnlyModelRessource):
 
     expected_list_size = 1
     expected_fields = ['label', 'event', 'task']
-
-    def target(self):
-        return self.meta_award

--- a/diffusion/tests/test_api_v2.py
+++ b/diffusion/tests/test_api_v2.py
@@ -1,0 +1,96 @@
+import pytest
+
+from utils.tests.utils import (
+    IsAuthenticatedOrReadOnlyModelViewSetMixin,
+    HelpTestForModelViewSet,
+    parametrize_user_roles,
+)
+
+
+def pytest_generate_tests(metafunc):
+    # pytest hook; called once per each test function
+    parametrize_user_roles(metafunc)
+
+
+@pytest.mark.django_db
+class TestPlaceViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'diffusion/place'
+
+    fixtures = ['place', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['latitude', 'longitude']
+
+    mutate_fields = ['name']
+
+
+@pytest.mark.django_db
+class TestAwardViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'diffusion/award'
+
+    fixtures = ['award', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['artwork', 'meta_award', 'event']
+
+    mutate_fields = ['note']
+
+
+@pytest.mark.django_db
+class TestMetaAwardViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'diffusion/meta-award'
+
+    fixtures = ['meta_award', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['event', 'type', 'task']
+
+    mutate_fields = ['label']
+    built_fields = {
+        'task': lambda x: {'label': x.task.label, 'description': x.task.description}
+    }
+
+    @pytest.mark.skip(reason="Putting and posting are impossible")
+    def test_put(self):
+        return
+
+    @pytest.mark.skip(reason="Putting and posting are impossible")
+    def test_post(self):
+        return
+
+
+@pytest.mark.django_db
+class TestMetaEventViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'diffusion/meta-event'
+
+    fixtures = ['meta_event', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['keywords', 'genres']
+
+    mutate_fields = ['genres']
+    put_fields = ['genres', 'keywords']
+    built_fields = {
+        'keywords': lambda x: list(x.keywords.values_list('name', flat=True))
+    }
+
+    @pytest.mark.skip(reason="Posting seems impossible")
+    def test_post(self):
+        return
+
+
+@pytest.mark.django_db
+class TestDiffusionViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'diffusion/diffusion'
+
+    fixtures = ['diffusion', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['on_competition', 'event', 'artwork']
+
+    mutate_fields = ['on_competition']
+    put_fields = []
+
+    @pytest.mark.skip(reason="Posting seems impossible")
+    def test_post(self):
+        return

--- a/people/serializers.py
+++ b/people/serializers.py
@@ -62,7 +62,7 @@ class UserSerializer(serializers.ModelSerializer):
         return validated_data
 
     def update(self, instance, validated_data):
-        profile_data = validated_data.pop('profile')
+        profile_data = validated_data.pop('profile', {})
 
         # Update User data
         instance.username = validated_data.get('username', instance.username)
@@ -71,7 +71,7 @@ class UserSerializer(serializers.ModelSerializer):
         instance.email = validated_data.get('email', instance.email)
 
         # Update UserProfile data
-        if not instance.profile:
+        if not hasattr(instance, 'profile'):
             FresnoyProfile.objects.create(user=instance, **profile_data)
 
         # set Values for UserProfile

--- a/people/tests/conftest.py
+++ b/people/tests/conftest.py
@@ -11,13 +11,10 @@ def profile(db_ready):
 
 
 @pytest.fixture
-def artist(db_ready):
-    return factories.ArtistFactory()
-
-
-@pytest.fixture
-def andy(db_ready):
-    return factories.ArtistFactory(nickname="Andy Warhol")
+def artist(db_ready, school_application_group):
+    artist = factories.ArtistFactory()
+    school_application_group.user_set.add(artist.user)
+    return artist
 
 
 @pytest.fixture

--- a/people/tests/test_api.py
+++ b/people/tests/test_api.py
@@ -52,6 +52,9 @@ class TestArtistRessource(HelpTestForReadOnlyModelRessource):
     expected_list_size = 1
     expected_fields = ['nickname', 'artworks', 'websites']
 
+    post_fields = ['user']
+    hyperlinked_fields = {'user': 'people/user'}
+
     def target(self):
         return self.artist
 
@@ -67,6 +70,9 @@ class TestStaffRessource(HelpTestForReadOnlyModelRessource):
 
     expected_list_size = 1
     expected_fields = ['user']
+
+    post_fields = ['user']
+    hyperlinked_fields = {'user': 'people/user'}
 
     def target(self):
         return self.staff

--- a/people/tests/test_api.py
+++ b/people/tests/test_api.py
@@ -52,9 +52,6 @@ class TestArtistRessource(HelpTestForReadOnlyModelRessource):
     post_fields = ['user']
     hyperlinked_fields = {'user': 'people/user'}
 
-    def target(self):
-        return self.artist
-
     def requestor(self, role):
         return self.artist.user
 
@@ -71,9 +68,6 @@ class TestStaffRessource(HelpTestForReadOnlyModelRessource):
     post_fields = ['user']
     hyperlinked_fields = {'user': 'people/user'}
 
-    def target(self):
-        return self.staff
-
     def requestor(self, role):
         return self.staff.user
 
@@ -86,6 +80,3 @@ class TestOrganizationRessource(HelpTestForReadOnlyModelRessource):
 
     expected_list_size = 2
     expected_fields = ['name']
-
-    def target(self):
-        return self.organization

--- a/people/tests/test_api.py
+++ b/people/tests/test_api.py
@@ -15,7 +15,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.mark.django_db
 class TestUserRessource(HelpTestForReadOnlyModelRessource):
-    model = api.UserResource
+    resource = api.UserResource
 
     fixtures = ['user', 'profile']
 
@@ -45,7 +45,7 @@ class TestUserProfileRessource(TestUserRessource):
 
 @pytest.mark.django_db
 class TestArtistRessource(HelpTestForReadOnlyModelRessource):
-    model = api.ArtistResource
+    resource = api.ArtistResource
 
     fixtures = ['artist', 'artist_profile', 'artist_website', 'artwork']
 
@@ -61,7 +61,7 @@ class TestArtistRessource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestStaffRessource(HelpTestForReadOnlyModelRessource):
-    model = api.StaffResource
+    resource = api.StaffResource
 
     fixtures = ['staff', 'staff_profile']
 
@@ -77,7 +77,7 @@ class TestStaffRessource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestOrganizationRessource(HelpTestForReadOnlyModelRessource):
-    model = api.OrganizationResource
+    resource = api.OrganizationResource
 
     fixtures = ['organization', 'place', 'user']
 

--- a/people/tests/test_api.py
+++ b/people/tests/test_api.py
@@ -25,9 +25,6 @@ class TestUserRessource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.user
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestUserProfileRessource(TestUserRessource):
@@ -39,7 +36,7 @@ class TestUserProfileRessource(TestUserRessource):
     def target(self):
         return self.profile.user
 
-    def requestor(self):
+    def requestor(self, role):
         return self.profile.user
 
 
@@ -58,7 +55,7 @@ class TestArtistRessource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.artist
 
-    def requestor(self):
+    def requestor(self, role):
         return self.artist.user
 
 
@@ -77,7 +74,7 @@ class TestStaffRessource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.staff
 
-    def requestor(self):
+    def requestor(self, role):
         return self.staff.user
 
 
@@ -92,6 +89,3 @@ class TestOrganizationRessource(HelpTestForReadOnlyModelRessource):
 
     def target(self):
         return self.organization
-
-    def requestor(self):
-        return self.user

--- a/people/tests/test_api_v2.py
+++ b/people/tests/test_api_v2.py
@@ -31,9 +31,6 @@ class TestUserViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForMod
     def target(self):
         return self.user
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestPrivateUserProfileViewSet(TestUserViewSet):
@@ -56,7 +53,7 @@ class TestPrivateUserProfileViewSet(TestUserViewSet):
     def target(self):
         return self.profile.user
 
-    def requestor(self):
+    def requestor(self, role):
         return self.profile.user
 
 
@@ -74,7 +71,7 @@ class TestProfileViewSet(HelpTestForModelViewSet):
     def target(self):
         return self.profile
 
-    def requestor(self):
+    def requestor(self, role):
         return self.profile.user
 
 
@@ -94,7 +91,7 @@ class TestArtistViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForM
     def target(self):
         return self.artist
 
-    def requestor(self):
+    def requestor(self, role):
         return self.artist.user
 
 
@@ -118,7 +115,7 @@ class TestStaffViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForMo
     def target(self):
         return self.staff
 
-    def requestor(self):
+    def requestor(self, role):
         return self.staff.user
 
 
@@ -136,6 +133,3 @@ class TestOrganizationViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTe
 
     def target(self):
         return self.organization
-
-    def requestor(self):
-        return self.user

--- a/people/tests/test_api_v2.py
+++ b/people/tests/test_api_v2.py
@@ -28,9 +28,6 @@ class TestUserViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForMod
     put_fields = ['username', 'last_name', 'first_name']
     built_fields = {'username': lambda x: x.username + '-bis'}
 
-    def target(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestPrivateUserProfileViewSet(TestUserViewSet):
@@ -69,9 +66,6 @@ class TestProfileViewSet(HelpTestForModelViewSet):
     mutate_fields = ['nationality']
     put_fields = ['nationality']
 
-    def target(self):
-        return self.profile
-
     def requestor(self, role):
         return self.profile.user
 
@@ -88,9 +82,6 @@ class TestArtistViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForM
     mutate_fields = ['nickname']
     put_fields = ['nickname', 'user']
     hyperlinked_fields = {'user': 'user'}
-
-    def target(self):
-        return self.artist
 
     def requestor(self, role):
         return self.artist.user
@@ -113,9 +104,6 @@ class TestStaffViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForMo
     def test_post(self):
         return
 
-    def target(self):
-        return self.staff
-
     def requestor(self, role):
         return self.staff.user
 
@@ -131,6 +119,3 @@ class TestOrganizationViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTe
 
     mutate_fields = ['name']
     put_fields = ['name', 'description']
-
-    def target(self):
-        return self.organization

--- a/people/tests/test_api_v2.py
+++ b/people/tests/test_api_v2.py
@@ -26,6 +26,7 @@ class TestUserViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForMod
 
     mutate_fields = ['username']
     put_fields = ['username', 'last_name', 'first_name']
+    built_fields = {'username': lambda x: x.username + '-bis'}
 
     def target(self):
         return self.user
@@ -48,7 +49,7 @@ class TestPrivateUserProfileViewSet(TestUserViewSet):
         'get': 200,
         'patch': 200,
         'put': 200,
-        'post': 405,
+        'post': 201,
         'delete': 204,
     }
 
@@ -109,6 +110,10 @@ class TestStaffViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForMo
     mutate_fields = ['user']
     put_fields = ['user']
     hyperlinked_fields = {'user': 'user'}
+
+    @pytest.mark.skip(reason="Posting seems impossible. DRF Bug?")
+    def test_post(self):
+        return
 
     def target(self):
         return self.staff

--- a/people/tests/test_api_v2.py
+++ b/people/tests/test_api_v2.py
@@ -39,7 +39,8 @@ class TestPrivateUserProfileViewSet(TestUserViewSet):
     expected_list_size = 1
     expected_fields = ['first_name', 'profile__nationality']
 
-    _user_roles = ['user', 'jwt']
+    _user_roles = ['user']
+    _auth_methods = ['forced']
 
     methods_behavior = {
         # list not tested since it only expose TestUserViewSet.expected_fields

--- a/people/tests/test_api_v2.py
+++ b/people/tests/test_api_v2.py
@@ -1,0 +1,136 @@
+import pytest
+
+from common.tests.conftest import *  # noqa
+from diffusion.tests.conftest import *  # noqa
+from production.tests.conftest import *  # noqa
+from utils.tests.utils import (
+    IsAuthenticatedOrReadOnlyModelViewSetMixin,
+    HelpTestForModelViewSet,
+    parametrize_user_roles,
+)
+
+
+def pytest_generate_tests(metafunc):
+    # pytest hook; called once per each test function
+    parametrize_user_roles(metafunc)
+
+
+@pytest.mark.django_db
+class TestUserViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'people/user'
+
+    fixtures = ['user', 'profile']
+
+    expected_list_size = 2
+    expected_fields = ['first_name']
+
+    mutate_fields = ['username']
+    put_fields = ['username', 'last_name', 'first_name']
+
+    def target(self):
+        return self.user
+
+    def requestor(self):
+        return self.user
+
+
+@pytest.mark.django_db
+class TestPrivateUserProfileViewSet(TestUserViewSet):
+    fixtures = ['profile']
+
+    expected_list_size = 1
+    expected_fields = ['first_name', 'profile__nationality']
+
+    _user_roles = ['user', 'jwt']
+
+    methods_behavior = {
+        # list not tested since it only expose TestUserViewSet.expected_fields
+        'get': 200,
+        'patch': 200,
+        'put': 200,
+        'post': 405,
+        'delete': 204,
+    }
+
+    def target(self):
+        return self.profile.user
+
+    def requestor(self):
+        return self.profile.user
+
+
+@pytest.mark.django_db
+class TestProfileViewSet(HelpTestForModelViewSet):
+    viewset_name = 'people/userprofile'
+    fixtures = ['profile']
+
+    expected_list_size = 1
+    expected_fields = ['birthdate', 'nationality']
+
+    mutate_fields = ['nationality']
+    put_fields = ['nationality']
+
+    def target(self):
+        return self.profile
+
+    def requestor(self):
+        return self.profile.user
+
+
+@pytest.mark.django_db
+class TestArtistViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'people/artist'
+
+    fixtures = ['artist', 'artist_profile', 'artist_website', 'artwork']
+
+    expected_list_size = 1
+    expected_fields = ['nickname', 'bio_short_fr', 'websites']
+
+    mutate_fields = ['nickname']
+    put_fields = ['nickname', 'user']
+    hyperlinked_fields = {'user': 'user'}
+
+    def target(self):
+        return self.artist
+
+    def requestor(self):
+        return self.artist.user
+
+
+@pytest.mark.django_db
+class TestStaffViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'people/staff'
+
+    fixtures = ['staff', 'staff_profile']
+
+    expected_list_size = 1
+    expected_fields = ['user']
+
+    mutate_fields = ['user']
+    put_fields = ['user']
+    hyperlinked_fields = {'user': 'user'}
+
+    def target(self):
+        return self.staff
+
+    def requestor(self):
+        return self.staff.user
+
+
+@pytest.mark.django_db
+class TestOrganizationViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'people/organization'
+
+    fixtures = ['organization', 'place', 'user']
+
+    expected_list_size = 2
+    expected_fields = ['name', 'description']
+
+    mutate_fields = ['name']
+    put_fields = ['name', 'description']
+
+    def target(self):
+        return self.organization
+
+    def requestor(self):
+        return self.user

--- a/people/tests/test_views.py
+++ b/people/tests/test_views.py
@@ -159,7 +159,6 @@ class TestSendCustomEmails:
 
         url = reverse('send-emails')
         response = getattr(client, method)(url, data=data)
-        print(response, response.content.decode())
 
         assert response.status_code == expected_code
         assert len(mailoutbox) == expected_email

--- a/people/tests/test_views.py
+++ b/people/tests/test_views.py
@@ -121,7 +121,7 @@ class TestSendCustomEmails:
         'user_role, method, expected_code, expected_email', [
             (None, 'post', 403, 0),
             ('user', 'post', 401, 0),
-            ('admin', 'post', 401, 0),
+            ('admin', 'post', 200, 1),
             ('staff', 'get', 406, 0),
             ('staff', 'post', 200, 1),
             ('staff_bad_request', 'post', 406, 0),

--- a/people/views.py
+++ b/people/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth.tokens import default_token_generator
 
@@ -28,8 +29,15 @@ from .serializers import (
 from .utils import send_activation_email, send_account_information_email
 
 
+# django-guardian anonymous user
+try:
+    ANONYMOUS_USER_NAME = settings.ANONYMOUS_USER_NAME
+except AttributeError:
+    ANONYMOUS_USER_NAME = "AnonymousUser"
+
+
 class UserViewSet(viewsets.ModelViewSet):
-    queryset = User.objects.all()
+    queryset = User.objects.exclude(username=ANONYMOUS_USER_NAME)
     # serializer_class = UserSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     filter_backends = (filters.SearchFilter,)

--- a/production/tests/conftest.py
+++ b/production/tests/conftest.py
@@ -42,6 +42,13 @@ def artwork(db_ready, artist):
 
 
 @pytest.fixture
+def film_keyword(db_ready, film):
+    tag = factories.TagFactory()
+    film.keywords.add(tag)
+    return tag
+
+
+@pytest.fixture
 def film_genre(db_ready):
     return factories.FilmGenreFactory()
 

--- a/production/tests/factories.py
+++ b/production/tests/factories.py
@@ -2,6 +2,7 @@ import factory
 import factory.fuzzy
 
 from django.utils import timezone
+from taggit.models import Tag
 
 from diffusion.tests.factories_alt import PlaceFactory
 from people.tests.factories import StaffFactory, OrganizationFactory
@@ -65,6 +66,14 @@ class ArtworkFactory(ProductionFactory):
             # A list of authors were passed in, use them
             for author in extracted:
                 self.authors.add(author)
+
+
+class TagFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Tag
+
+    name = factory.Faker('word')
+    slug = factory.Faker('slug')
 
 
 class FilmGenreFactory(factory.django.DjangoModelFactory):

--- a/production/tests/test_api.py
+++ b/production/tests/test_api.py
@@ -21,13 +21,10 @@ def pytest_generate_tests(metafunc):
 class TestStaffTaskRessource(HelpTestForReadOnlyModelRessource):
     resource = api.StaffTaskResource
 
-    fixtures = ['user', 'staff_task']
+    fixtures = ['staff_task', 'user']
 
     expected_list_size = 1
     expected_fields = ['label']
-
-    def target(self):
-        return self.staff_task
 
 
 @pytest.mark.django_db
@@ -38,90 +35,69 @@ class TestArtworkRessource(
 ):
     resource = api.ArtworkResource
 
-    fixtures = ['user', 'installation', 'film', 'award']
+    fixtures = ['installation', 'film', 'award', 'user']
 
     expected_list_size = 2
     expected_fields = ['production_date', 'authors', 'events']
 
     search_field = 'title'
 
-    def target(self):
-        return self.installation
-
 
 @pytest.mark.django_db
 class TestInstallationResource(HelpTestForReadOnlyModelRessource):
     resource = api.InstallationResource
 
-    fixtures = ['user', 'installation']
+    fixtures = ['installation', 'user']
 
     expected_list_size = 1
     expected_fields = ['production_date', 'authors', 'events', 'genres', 'technical_description']
-
-    def target(self):
-        return self.installation
 
 
 @pytest.mark.django_db
 class TestFilmResource(HelpTestForReadOnlyModelRessource):
     resource = api.FilmResource
 
-    fixtures = ['user', 'film']
+    fixtures = ['film', 'user']
 
     expected_list_size = 1
     expected_fields = ['production_date', 'authors', 'events', 'genres', 'aspect_ratio']
-
-    def target(self):
-        return self.film
 
 
 @pytest.mark.django_db
 class TestPerformanceResource(HelpTestForReadOnlyModelRessource):
     resource = api.PerformanceResource
 
-    fixtures = ['user', 'performance']
+    fixtures = ['performance', 'user']
 
     expected_list_size = 1
     expected_fields = ['production_date', 'authors', 'events']
-
-    def target(self):
-        return self.performance
 
 
 @pytest.mark.django_db
 class TestEventResource(HelpTestForReadOnlyModelRessource):
     resource = api.EventResource
 
-    fixtures = ['user', 'event']
+    fixtures = ['event', 'user']
 
     expected_list_size = 1
     expected_fields = ['type', 'place', 'installations', 'films', 'performances']
-
-    def target(self):
-        return self.event
 
 
 @pytest.mark.django_db
 class TestItineraryResource(HelpTestForReadOnlyModelRessource):
     resource = api.ItineraryResource
 
-    fixtures = ['user', 'itinerary']
+    fixtures = ['itinerary', 'user']
 
     expected_list_size = 1
     expected_fields = ['label_fr', 'label_en', 'artworks']
-
-    def target(self):
-        return self.itinerary
 
 
 @pytest.mark.django_db
 class TestExhibitionResource(TestEventResource):
     resource = api.ExhibitionResource
 
-    fixtures = ['user', 'exhibition']
+    fixtures = ['exhibition', 'user']
 
     expected_list_size = 1
     expected_fields = ['type', 'place', 'installations', 'films', 'performances', 'itineraries']
-
-    def target(self):
-        return self.exhibition

--- a/production/tests/test_api.py
+++ b/production/tests/test_api.py
@@ -19,7 +19,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.mark.django_db
 class TestStaffTaskRessource(HelpTestForReadOnlyModelRessource):
-    model = api.StaffTaskResource
+    resource = api.StaffTaskResource
 
     fixtures = ['user', 'staff_task']
 
@@ -39,7 +39,7 @@ class TestArtworkRessource(
     FilterModelRessourceMixin,
     HelpTestForReadOnlyModelRessource,
 ):
-    model = api.ArtworkResource
+    resource = api.ArtworkResource
 
     fixtures = ['user', 'installation', 'film', 'award']
 
@@ -57,7 +57,7 @@ class TestArtworkRessource(
 
 @pytest.mark.django_db
 class TestInstallationResource(HelpTestForReadOnlyModelRessource):
-    model = api.InstallationResource
+    resource = api.InstallationResource
 
     fixtures = ['user', 'installation']
 
@@ -73,7 +73,7 @@ class TestInstallationResource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestFilmResource(HelpTestForReadOnlyModelRessource):
-    model = api.FilmResource
+    resource = api.FilmResource
 
     fixtures = ['user', 'film']
 
@@ -89,7 +89,7 @@ class TestFilmResource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestPerformanceResource(HelpTestForReadOnlyModelRessource):
-    model = api.PerformanceResource
+    resource = api.PerformanceResource
 
     fixtures = ['user', 'performance']
 
@@ -105,7 +105,7 @@ class TestPerformanceResource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestEventResource(HelpTestForReadOnlyModelRessource):
-    model = api.EventResource
+    resource = api.EventResource
 
     fixtures = ['user', 'event']
 
@@ -121,7 +121,7 @@ class TestEventResource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestItineraryResource(HelpTestForReadOnlyModelRessource):
-    model = api.ItineraryResource
+    resource = api.ItineraryResource
 
     fixtures = ['user', 'itinerary']
 
@@ -137,7 +137,7 @@ class TestItineraryResource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestExhibitionResource(TestEventResource):
-    model = api.ExhibitionResource
+    resource = api.ExhibitionResource
 
     fixtures = ['user', 'exhibition']
 

--- a/production/tests/test_api.py
+++ b/production/tests/test_api.py
@@ -29,9 +29,6 @@ class TestStaffTaskRessource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.staff_task
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestArtworkRessource(
@@ -51,9 +48,6 @@ class TestArtworkRessource(
     def target(self):
         return self.installation
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestInstallationResource(HelpTestForReadOnlyModelRessource):
@@ -66,9 +60,6 @@ class TestInstallationResource(HelpTestForReadOnlyModelRessource):
 
     def target(self):
         return self.installation
-
-    def requestor(self):
-        return self.user
 
 
 @pytest.mark.django_db
@@ -83,9 +74,6 @@ class TestFilmResource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.film
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestPerformanceResource(HelpTestForReadOnlyModelRessource):
@@ -98,9 +86,6 @@ class TestPerformanceResource(HelpTestForReadOnlyModelRessource):
 
     def target(self):
         return self.performance
-
-    def requestor(self):
-        return self.user
 
 
 @pytest.mark.django_db
@@ -115,9 +100,6 @@ class TestEventResource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.event
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestItineraryResource(HelpTestForReadOnlyModelRessource):
@@ -131,9 +113,6 @@ class TestItineraryResource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.itinerary
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestExhibitionResource(TestEventResource):
@@ -146,6 +125,3 @@ class TestExhibitionResource(TestEventResource):
 
     def target(self):
         return self.exhibition
-
-    def requestor(self):
-        return self.user

--- a/production/tests/test_api_v2.py
+++ b/production/tests/test_api_v2.py
@@ -159,9 +159,6 @@ class TestFilmGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
 
     mutate_fields = ['label']
 
-    def target(self):
-        return self.film_genre
-
 
 @pytest.mark.django_db
 class TestInstallationGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):

--- a/production/tests/test_api_v2.py
+++ b/production/tests/test_api_v2.py
@@ -36,7 +36,7 @@ class TestArtworkViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
     def target(self):
         return self.installation
 
-    def requestor(self):
+    def requestor(self, role):
         return self.installation.authors.first().user
 
 
@@ -59,7 +59,7 @@ class TestFilmViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
     def target(self):
         return self.film
 
-    def requestor(self):
+    def requestor(self, role):
         return self.film.authors.first().user
 
 
@@ -82,7 +82,7 @@ class TestInstallationViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet
     def target(self):
         return self.installation
 
-    def requestor(self):
+    def requestor(self, role):
         return self.installation.authors.first().user
 
 
@@ -105,7 +105,7 @@ class TestPerformanceViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet)
     def target(self):
         return self.performance
 
-    def requestor(self):
+    def requestor(self, role):
         return self.performance.authors.first().user
 
 
@@ -123,9 +123,6 @@ class TestEventViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
 
     def target(self):
         return self.event
-
-    def requestor(self):
-        return self.user
 
 
 @pytest.mark.django_db
@@ -150,9 +147,6 @@ class TestItineraryViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
     def target(self):
         return self.itinerary
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestFilmGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
@@ -169,9 +163,6 @@ class TestFilmGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
     def target(self):
         return self.film_genre
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestInstallationGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
@@ -187,9 +178,6 @@ class TestInstallationGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelVi
 
     def target(self):
         return self.installation_genre
-
-    def requestor(self):
-        return self.user
 
 
 @pytest.mark.django_db
@@ -211,7 +199,7 @@ class TestCollaboratorViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet
     def target(self):
         return self.production_staff_task
 
-    def requestor(self):
+    def requestor(self, role):
         return self.production_staff_task.staff.user
 
 
@@ -234,9 +222,6 @@ class TestPartnerViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
     def target(self):
         return self.production_organization_task
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestOrganizationTaskViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
@@ -254,9 +239,6 @@ class TestOrganizationTaskViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelVie
     def target(self):
         return self.organization_task
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestFilmKeywordsViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
@@ -272,6 +254,3 @@ class TestFilmKeywordsViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet
 
     def target(self):
         return self.film_keyword
-
-    def requestor(self):
-        return self.user

--- a/production/tests/test_api_v2.py
+++ b/production/tests/test_api_v2.py
@@ -5,6 +5,7 @@ from common.tests.conftest import *  # noqa
 from diffusion.tests.conftest import *  # noqa
 from people.tests.conftest import *  # noqa
 from utils.tests.utils import (
+    IsArtistOrReadOnlyModelViewSetMixin,
     ReadOnlyModelViewSetMixin,
     HelpTestForModelViewSet,
     parametrize_user_roles,
@@ -149,10 +150,10 @@ class TestItineraryViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
 
 
 @pytest.mark.django_db
-class TestFilmGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+class TestFilmGenreViewSet(IsArtistOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
     viewset_name = 'production/film-genre'
 
-    fixtures = ['film_genre', 'user']
+    fixtures = ['film_genre', 'artist', 'user']
 
     expected_list_size = 1
     expected_fields = ['label']

--- a/production/tests/test_api_v2.py
+++ b/production/tests/test_api_v2.py
@@ -1,0 +1,277 @@
+import pytest
+
+from django.urls import reverse
+from common.tests.conftest import *  # noqa
+from diffusion.tests.conftest import *  # noqa
+from people.tests.conftest import *  # noqa
+from utils.tests.utils import (
+    ReadOnlyModelViewSetMixin,
+    HelpTestForModelViewSet,
+    parametrize_user_roles,
+)
+
+
+def pytest_generate_tests(metafunc):
+    # pytest hook; called once per each test function
+    parametrize_user_roles(metafunc)
+
+
+@pytest.mark.django_db
+class TestArtworkViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/artwork'
+
+    fixtures = ['installation', 'film', 'award']
+
+    expected_list_size = 2
+    expected_fields = ['production_date', 'authors', 'title', 'description_fr']
+
+    mutate_fields = ['title']
+    put_fields = ['type', 'authors', 'genres', 'production_date', 'title']
+    built_fields = {
+        'type': lambda x: 'Installation',
+        'authors': lambda x: [reverse('artist-detail', kwargs={'pk': x.authors.first().pk})],
+        'genres': lambda x: [],
+    }
+
+    def target(self):
+        return self.installation
+
+    def requestor(self):
+        return self.installation.authors.first().user
+
+
+@pytest.mark.django_db
+class TestFilmViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/film'
+
+    fixtures = ['film']
+
+    expected_list_size = 1
+    expected_fields = ['production_date', 'authors', 'genres', 'aspect_ratio']
+
+    mutate_fields = ['title']
+    put_fields = ['authors', 'genres', 'production_date', 'title']
+    built_fields = {
+        'authors': lambda x: [reverse('artist-detail', kwargs={'pk': x.authors.first().pk})],
+        'genres': lambda x: [],
+    }
+
+    def target(self):
+        return self.film
+
+    def requestor(self):
+        return self.film.authors.first().user
+
+
+@pytest.mark.django_db
+class TestInstallationViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/installation'
+
+    fixtures = ['installation']
+
+    expected_list_size = 1
+    expected_fields = ['production_date', 'authors', 'genres', 'technical_description']
+
+    mutate_fields = ['title']
+    put_fields = ['authors', 'genres', 'production_date', 'title']
+    built_fields = {
+        'authors': lambda x: [reverse('artist-detail', kwargs={'pk': x.authors.first().pk})],
+        'genres': lambda x: [],
+    }
+
+    def target(self):
+        return self.installation
+
+    def requestor(self):
+        return self.installation.authors.first().user
+
+
+@pytest.mark.django_db
+class TestPerformanceViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/performance'
+
+    fixtures = ['performance']
+
+    expected_list_size = 1
+    expected_fields = ['production_date', 'authors']
+
+    mutate_fields = ['title']
+    put_fields = ['authors', 'genres', 'production_date', 'title']
+    built_fields = {
+        'authors': lambda x: [reverse('artist-detail', kwargs={'pk': x.authors.first().pk})],
+        'genres': lambda x: [],
+    }
+
+    def target(self):
+        return self.performance
+
+    def requestor(self):
+        return self.performance.authors.first().user
+
+
+@pytest.mark.django_db
+class TestEventViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/event'
+
+    fixtures = ['user', 'event']
+
+    expected_list_size = 1
+    expected_fields = ['type', 'place', 'installations', 'films', 'performances']
+
+    mutate_fields = ['title']
+    put_fields = ['starting_date', 'title', 'type']
+
+    def target(self):
+        return self.event
+
+    def requestor(self):
+        return self.user
+
+
+@pytest.mark.django_db
+class TestItineraryViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/itinerary'
+
+    fixtures = ['user', 'itinerary']
+
+    expected_list_size = 1
+    expected_fields = ['label_fr', 'label_en', 'artworks']
+
+    mutate_fields = ['label_fr']
+    put_fields = [
+        'description_en',
+        'description_fr',
+        'event',
+        'label_en',
+        'label_fr',
+    ]
+    hyperlinked_fields = {'event': 'event'}
+
+    def target(self):
+        return self.itinerary
+
+    def requestor(self):
+        return self.user
+
+
+@pytest.mark.django_db
+class TestFilmGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/film-genre'
+
+    fixtures = ['film_genre', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['label']
+
+    mutate_fields = ['label']
+    put_fields = ['label']
+
+    def target(self):
+        return self.film_genre
+
+    def requestor(self):
+        return self.user
+
+
+@pytest.mark.django_db
+class TestInstallationGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/installation-genre'
+
+    fixtures = ['installation_genre', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['label']
+
+    mutate_fields = ['label']
+    put_fields = ['label']
+
+    def target(self):
+        return self.installation_genre
+
+    def requestor(self):
+        return self.user
+
+
+@pytest.mark.django_db
+class TestCollaboratorViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/collaborator'
+
+    fixtures = ['production_staff_task']
+
+    expected_list_size = 1
+    expected_fields = ['staff', 'task']
+
+    mutate_fields = ['staff']
+    put_fields = ['staff', 'task']
+    hyperlinked_fields = {'staff': 'staff'}
+    built_fields = {
+        'task': lambda x: {'label': x.task.label, 'description': x.task.description}
+    }
+
+    def target(self):
+        return self.production_staff_task
+
+    def requestor(self):
+        return self.production_staff_task.staff.user
+
+
+@pytest.mark.django_db
+class TestPartnerViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/partner'
+
+    fixtures = ['production_organization_task', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['organization', 'task']
+
+    mutate_fields = ['organization']
+    put_fields = ['organization', 'task']
+    hyperlinked_fields = {'organization': 'organization'}
+    built_fields = {
+        'task': lambda x: {'label': x.task.label, 'description': x.task.description}
+    }
+
+    def target(self):
+        return self.production_organization_task
+
+    def requestor(self):
+        return self.user
+
+
+@pytest.mark.django_db
+class TestOrganizationTaskViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    # FIXME people?
+    viewset_name = 'people/organization-staff'
+
+    fixtures = ['organization_task', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['label', 'description']
+
+    mutate_fields = ['label']
+    put_fields = ['label', 'description']
+
+    def target(self):
+        return self.organization_task
+
+    def requestor(self):
+        return self.user
+
+
+@pytest.mark.django_db
+class TestFilmKeywordsViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'production/film-keywords'
+
+    fixtures = ['film_keyword', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['name', 'slug']
+
+    mutate_fields = ['name']
+    put_fields = ['name', 'slug']
+
+    def target(self):
+        return self.film_keyword
+
+    def requestor(self):
+        return self.user

--- a/production/tests/test_api_v2.py
+++ b/production/tests/test_api_v2.py
@@ -158,7 +158,6 @@ class TestFilmGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
     expected_fields = ['label']
 
     mutate_fields = ['label']
-    put_fields = ['label']
 
     def target(self):
         return self.film_genre
@@ -174,7 +173,6 @@ class TestInstallationGenreViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelVi
     expected_fields = ['label']
 
     mutate_fields = ['label']
-    put_fields = ['label']
 
     def target(self):
         return self.installation_genre

--- a/school/tests/factories.py
+++ b/school/tests/factories.py
@@ -35,6 +35,8 @@ class StudentApplicationSetupFactory(factory.django.DjangoModelFactory):
     candidature_date_start = factory.Faker('date_time_this_year', before_now=True, after_now=False, tzinfo=timezone.utc)
     candidature_date_end = factory.Faker('date_time_this_year', before_now=False, after_now=True, tzinfo=timezone.utc)
     date_of_birth_max = factory.Faker('date_of_birth', minimum_age=15, tzinfo=timezone.utc)
+    interviews_start_date = factory.SelfAttribute('candidature_date_end')
+    interviews_end_date = factory.SelfAttribute('candidature_date_end')
 
 
 class StudentApplicationFactory(factory.django.DjangoModelFactory):
@@ -42,3 +44,4 @@ class StudentApplicationFactory(factory.django.DjangoModelFactory):
         model = models.StudentApplication
 
     artist = factory.SubFactory(ArtistFactory)
+    campaign = factory.SubFactory(StudentApplicationSetupFactory)

--- a/school/tests/test_api.py
+++ b/school/tests/test_api.py
@@ -40,6 +40,9 @@ class TestStudentRessource(HaystackSearchModelRessourceMixin, HelpTestForReadOnl
     expected_list_size = 1
     expected_fields = ['number', 'promotion', 'artist']
 
+    post_fields = ['user', 'artist']
+    hyperlinked_fields = {'user': 'people/user', 'artist': 'people/artist'}
+
     search_field = 'number'
 
     def target(self):
@@ -79,7 +82,7 @@ class TestStudentApplicationRessource(HelpTestForReadOnlyModelRessource):
         'get': 401,
         'patch': 401,
         'put': 401,
-        'post': 501,
+        'post': 401,
         'delete': 401,
     }
 

--- a/school/tests/test_api.py
+++ b/school/tests/test_api.py
@@ -55,7 +55,7 @@ class TestStudentRessource(HaystackSearchModelRessourceMixin, HelpTestForReadOnl
         kwargs = self.prepare_request(client, user_role, data)
         response = client.get(self.base_url, **kwargs)
 
-        if self.thats_all_folk('list', response):
+        if self.thats_all_folk('list', response, user_role):
             return
 
         answer = response.json()

--- a/school/tests/test_api.py
+++ b/school/tests/test_api.py
@@ -17,7 +17,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.mark.django_db
 class TestPromotionRessource(HelpTestForReadOnlyModelRessource):
-    model = api.PromotionResource
+    resource = api.PromotionResource
 
     fixtures = ['user', 'promotion']
 
@@ -33,7 +33,7 @@ class TestPromotionRessource(HelpTestForReadOnlyModelRessource):
 
 @pytest.mark.django_db
 class TestStudentRessource(HaystackSearchModelRessourceMixin, HelpTestForReadOnlyModelRessource):
-    model = api.StudentResource
+    resource = api.StudentResource
 
     fixtures = ['student']
 
@@ -67,7 +67,7 @@ class TestStudentRessource(HaystackSearchModelRessourceMixin, HelpTestForReadOnl
 
 @pytest.mark.django_db
 class TestStudentApplicationRessource(HelpTestForReadOnlyModelRessource):
-    model = api.StudentApplicationResource
+    resource = api.StudentApplicationResource
 
     fixtures = ['student_application']
 

--- a/school/tests/test_api.py
+++ b/school/tests/test_api.py
@@ -27,9 +27,6 @@ class TestPromotionRessource(HelpTestForReadOnlyModelRessource):
     def target(self):
         return self.promotion
 
-    def requestor(self):
-        return self.user
-
 
 @pytest.mark.django_db
 class TestStudentRessource(HaystackSearchModelRessourceMixin, HelpTestForReadOnlyModelRessource):
@@ -48,7 +45,7 @@ class TestStudentRessource(HaystackSearchModelRessourceMixin, HelpTestForReadOnl
     def target(self):
         return self.student
 
-    def requestor(self):
+    def requestor(self, role):
         return self.student.user
 
     def test_user__last_name__istartswith_search(self, client, user_role, request):

--- a/school/tests/test_api.py
+++ b/school/tests/test_api.py
@@ -48,11 +48,11 @@ class TestStudentRessource(HaystackSearchModelRessourceMixin, HelpTestForReadOnl
     def requestor(self, role):
         return self.student.user
 
-    def test_user__last_name__istartswith_search(self, client, user_role, request):
+    def test_user__last_name__istartswith_search(self, client, user_role, auth_method, request):
         self.setup_fixtures(request)
 
         data = {'user__last_name__istartswith': self.student.user.last_name[0]}
-        kwargs = self.prepare_request(client, user_role, data)
+        kwargs = self.prepare_request(client, user_role, auth_method, data)
         response = client.get(self.base_url, **kwargs)
 
         if self.thats_all_folk('list', response, user_role):

--- a/school/tests/test_api_v2.py
+++ b/school/tests/test_api_v2.py
@@ -1,0 +1,196 @@
+import pytest
+
+from django.urls import reverse
+from django.utils import timezone
+
+from people.tests.conftest import *  # noqa
+from utils.tests.utils import (
+    IgnoreModelViewSetMixin,
+    IsArtistOrReadOnlyModelViewSetMixin,
+    IsAuthenticatedOrReadOnlyModelViewSetMixin,
+    ReadOnlyModelViewSetMixin,
+    HelpTestForModelViewSet,
+    parametrize_user_roles,
+)
+
+
+def pytest_generate_tests(metafunc):
+    # pytest hook; called once per each test function
+    parametrize_user_roles(metafunc)
+
+
+@pytest.mark.django_db
+class TestPromotionViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'school/promotion'
+
+    fixtures = ['promotion', 'user']
+
+    expected_list_size = 1
+    expected_fields = ['starting_year', 'ending_year']
+
+    mutate_fields = ['name']
+    put_fields = ['name', 'starting_year', 'ending_year']
+
+
+@pytest.mark.django_db
+class TestStudentViewSet(IsAuthenticatedOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'school/student'
+
+    fixtures = ['student', 'user', 'artist']
+
+    expected_list_size = 1
+    expected_fields = ['number', 'promotion']
+
+    mutate_fields = ['number']
+    put_fields = ['artist', 'user']
+    built_fields = {
+        'artist': lambda x: reverse('artist-detail', kwargs={'pk': x.artist.pk}),
+        'user': lambda x: reverse('user-detail', kwargs={'pk': x.user.pk}),
+    }
+
+    def get_data(self, field):
+        if field in self.built_fields:
+            return self.built_fields[field](self)
+        else:
+            return super().get_data(field)
+
+
+@pytest.mark.django_db
+class TestStudentApplicationSetupViewSet(IsArtistOrReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'school/student-application-setup'
+
+    fixtures = ['student_application_setup', 'user', 'artist']
+
+    expected_list_size = 1
+    expected_fields = ['candidature_date_start', 'candidature_date_end']
+
+    mutate_fields = ['date_of_birth_max']
+    put_fields = ['candidature_date_start', 'candidature_date_end']
+
+
+@pytest.mark.django_db
+class TestArtistStudentApplicationViewSet(HelpTestForModelViewSet):
+    viewset_name = 'school/student-application'
+
+    fixtures = ['student_application']
+
+    expected_list_size = 1
+    expected_fields = ['curriculum_vitae']
+
+    mutate_fields = ['remark']
+    put_fields = []
+
+    _user_roles = ['user']
+
+    def requestor(self, role):
+        return self.student_application.artist.user
+
+    methods_behavior = {
+        'list': 200,
+        'get': 200,
+        'patch': 200,
+        'put': 200,
+        'post': 409,
+        'delete': 204,
+    }
+
+
+@pytest.mark.django_db
+class TestUserStudentApplicationViewSet(TestArtistStudentApplicationViewSet):
+    fixtures = ['student_application', 'user']
+
+    def requestor(self, role):
+        return self.user
+
+    expected_list_size = 0
+
+    methods_behavior = {
+        'list': 200,
+        'get': 404,
+        'patch': 404,
+        'put': 404,
+        'post': 201,
+        'delete': 404,
+    }
+
+
+@pytest.mark.django_db
+class TestUserStudentApplicationClosedCampaign(IgnoreModelViewSetMixin, TestUserStudentApplicationViewSet):
+
+    methods_behavior = {
+        'post': 403,
+        'put': 403,
+        'patch': 403,
+    }
+
+    def munge_fixtures(self, request):
+        self.setup_fixtures(request)
+
+        campaign = self.student_application.campaign
+        campaign.is_current_setup = True
+        campaign.candidature_date_end = campaign.candidature_date_start
+        campaign.save()
+
+        # avoid fixture reinstallation
+        self.setup_fixtures = lambda request: None
+
+    def test_patch_on_closed_campaign(self, client, user_role, auth_method, request):
+        self.munge_fixtures(request)
+        super(TestUserStudentApplicationViewSet, self).test_patch(client, user_role, auth_method, request)
+
+    def test_put_on_closed_campaign(self, client, user_role, auth_method, request):
+        self.munge_fixtures(request)
+        super(TestUserStudentApplicationViewSet, self).test_put(client, user_role, auth_method, request)
+
+    def test_post_on_closed_campaign(self, client, user_role, auth_method, request):
+        self.munge_fixtures(request)
+        super(TestUserStudentApplicationViewSet, self).test_post(client, user_role, auth_method, request)
+
+    @pytest.mark.parametrize('action, mailsent', [
+        # ['application_completed', 2],  # FIXME: dead code
+        ['application_complete', 1],
+        ['wait_listed_for_interview', 1],
+        ['selected_for_interview', 1],
+        ['unselected', 1],
+    ])
+    def test_patch_with_mail_action(self, client, admin, student_application, action, mailsent, mailoutbox):
+        self.student_application = student_application
+        self.student_application.interview_date = timezone.now()
+        self.student_application.save()
+
+        client.force_login(admin)
+
+        kwargs = {
+            'data': {action: 1},
+            'content_type': 'application/json',
+        }
+        response = client.patch('{}/{}'.format(self.base_url, self.target_uri_suffix()), **kwargs)
+        assert response.status_code == 200
+        assert len(mailoutbox) == mailsent
+
+    def test_abusive_patch_with_mail_action(self, client, artist, student_application):
+        self.student_application = student_application
+
+        client.force_login(artist.user)
+
+        kwargs = {
+            'data': {'selected_for_interview': 1},
+            'content_type': 'application/json',
+        }
+        response = client.patch('{}/{}'.format(self.base_url, self.target_uri_suffix()), **kwargs)
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+class TestAnonymousStudentApplicationViewSet(ReadOnlyModelViewSetMixin, HelpTestForModelViewSet):
+    viewset_name = 'school/student-application'
+
+    fixtures = ['student_application']
+
+    expected_list_size = 1
+    expected_fields = ['id', 'url']
+
+    mutate_fields = ['id']
+    put_fields = []
+
+    _user_roles = [None]

--- a/school/views.py
+++ b/school/views.py
@@ -134,6 +134,7 @@ class StudentApplicationViewSet(viewsets.ModelViewSet):
                 errors = {'candidature': 'you are not able to create another candidature this session'}
                 return Response(errors, status=status.HTTP_409_CONFLICT)
         else:
+            # FIXME: dead code: handled by APIView.permission_denied which raise HTTP_403
             errors = {'candidature': 'forbidden'}
             return Response(errors, status=status.HTTP_403_FORBIDDEN)
 
@@ -161,12 +162,13 @@ class StudentApplicationViewSet(viewsets.ModelViewSet):
                 request.data.get('wait_listed_for_interview') or
                 request.data.get('position_in_waitlist') or
                 request.data.get('position_in_interview_waitlist') or
-                request.data.get('application_complete') or
+                request.data.get('application_complete') or  # FIXME: complete or completed?
                 request.data.get('campaign'))
         ):
             errors = {'Error': 'Field permission denied'}
             return Response(errors, status=status.HTTP_403_FORBIDDEN)
 
+        # FIXME: dead code since it never pass througth the previous test
         # send email to admin and USER (who click) is completed
         if(request.data.get('application_completed')):
             application = self.get_object()

--- a/utils/tests/conftest.py
+++ b/utils/tests/conftest.py
@@ -40,7 +40,7 @@ def school_application_group(db_ready):
         "add_filmgenre",
         "add_gallery",
         "add_medium",
-        "add_promotion",
+        "add_promotion",  # FIXME: a priori pas nécessaire
         "add_stafftask",
         "add_student",
         "add_studentapplication",

--- a/utils/tests/conftest.py
+++ b/utils/tests/conftest.py
@@ -34,20 +34,37 @@ def joker(db_ready):
 
 @pytest.fixture
 def school_application_group(db_ready):
-    # FIXME: c'est ce que je comprends de la fixture groups.json
     # FIXME: amha ça mériterais une migration
     perms = [
-        'view_staff',
-        'delete_staff',
-        'add_itinerary',
-        'change_itinerary',
-        'delete_itinerary',
-        'view_itinerary',
-        'view_organizationtask',
-        'delete_organizationtask',
-        'add_production',
-        'add_taggeditem',
-        'change_taggeditem',
+        "add_corsmodel",
+        "add_filmgenre",
+        "add_gallery",
+        "add_medium",
+        "add_promotion",
+        "add_stafftask",
+        "add_student",
+        "add_studentapplication",
+        "add_studentapplicationsetup",
+        "add_userobjectpermission",
+        "change_corsmodel",
+        "change_filmgenre",
+        "change_gallery",
+        "change_medium",
+        "change_promotion",
+        "change_stafftask",
+        "change_student",
+        "change_studentapplication",
+        "change_studentapplicationsetup",
+        "change_userobjectpermission",
+        "delete_corsmodel",
+        "delete_filmgenre",
+        "delete_gallery",
+        "delete_medium",
+        "delete_promotion",
+        "delete_student",
+        "delete_studentapplication",
+        "delete_studentapplicationsetup",
+        "delete_userobjectpermission",
     ]
 
     group = Group.objects.create(name='School Application')

--- a/utils/tests/factories.py
+++ b/utils/tests/factories.py
@@ -31,3 +31,4 @@ class UserFactory(factory.django.DjangoModelFactory):
 class AdminFactory(UserFactory):
     is_superuser = True
     is_active = True
+    is_staff = True

--- a/utils/tests/utils.py
+++ b/utils/tests/utils.py
@@ -74,9 +74,15 @@ class AbstractHelpTestForAPI:
         else:
             return True
 
+    def requestor(self, role):
+        if role == 'user':
+            return self.user
+        if role == 'artist':
+            return self.artist.user
+
     def prepare_request(self, client, user_role, data=None, json=True):
-        if user_role == 'user':
-            client.force_login(self.requestor())
+        if user_role in ['artist', 'user']:
+            client.force_login(self.requestor(user_role))
 
         kwargs = {}
         if json:
@@ -86,7 +92,7 @@ class AbstractHelpTestForAPI:
             kwargs['data'] = data
 
         if user_role == 'jwt':
-            jwt = obtain_jwt_token(self.requestor())
+            jwt = obtain_jwt_token(self.requestor('user'))  # FIXME: obsolete
             kwargs['HTTP_AUTHORIZATION'] = 'JWT {}'.format(jwt['token'])
 
         return kwargs

--- a/utils/tests/utils.py
+++ b/utils/tests/utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from django.db.models.constants import LOOKUP_SEP
 from django.test import Client
 from django.urls import reverse
@@ -276,6 +278,34 @@ class ReadOnlyModelViewSetMixin:
         'post': 403,
         'delete': 403,
     }
+
+
+class IgnoreModelViewSetMixin:
+    methods_behavior = {}
+
+    @pytest.mark.skip()
+    def test_list(self):
+        pass
+
+    @pytest.mark.skip()
+    def test_get(self):
+        pass
+
+    @pytest.mark.skip()
+    def test_patch(self):
+        pass
+
+    @pytest.mark.skip()
+    def test_put(self):
+        pass
+
+    @pytest.mark.skip()
+    def test_post(self):
+        pass
+
+    @pytest.mark.skip()
+    def test_delete(self):
+        pass
 
 
 class HelpTestForModelRessource(AbstractHelpTestForAPI):

--- a/utils/tests/utils.py
+++ b/utils/tests/utils.py
@@ -93,6 +93,9 @@ class AbstractHelpTestForAPI:
         else:
             return True
 
+    def target(self):
+        return getattr(self, self.fixtures[0])
+
     def requestor(self, role):
         if role == 'user':
             return self.user

--- a/utils/tests/utils.py
+++ b/utils/tests/utils.py
@@ -166,7 +166,7 @@ class AbstractHelpTestForAPI:
     def test_post(self, client, user_role, auth_method, request):
         self.setup_fixtures(request)
 
-        fields = getattr(self, 'post_fields', self.put_fields)
+        fields = getattr(self, 'post_fields', getattr(self, 'put_fields', self.mutate_fields))
         data = {f: self.get_data(f) for f in fields}
         kwargs = self.prepare_request(client, user_role, auth_method, data)
         response = client.post(self.base_url, **kwargs)
@@ -177,7 +177,8 @@ class AbstractHelpTestForAPI:
     def test_put(self, client, user_role, auth_method, request):
         self.setup_fixtures(request)
 
-        data = {f: self.get_data(f) for f in self.put_fields}
+        fields = getattr(self, 'put_fields', self.mutate_fields)
+        data = {f: self.get_data(f) for f in fields}
         kwargs = self.prepare_request(client, user_role, auth_method, data)
         response = client.put('{}/{}'.format(self.base_url, self.target_uri_suffix()), **kwargs)
 
@@ -267,10 +268,6 @@ class HelpTestForModelRessource(AbstractHelpTestForAPI):
     Help to test interfaces to ModelResource (tastypie)
     """
     url_prefix = "/v1"
-
-    @property
-    def put_fields(self):
-        return self.mutate_fields
 
     @property
     def uri(self):

--- a/utils/tests/utils.py
+++ b/utils/tests/utils.py
@@ -254,8 +254,20 @@ class IsAuthenticatedOrReadOnlyModelViewSetMixin:
     }
 
 
-class ReadOnlyModelViewSetMixin:
+class IsArtistOrReadOnlyModelViewSetMixin:
+    _user_roles = [None, 'user', 'artist']
 
+    methods_behavior = {
+        'list': 200,
+        'get': 200,
+        'patch': {None: 403, 'user': 403, 'artist': 200},
+        'put': {None: 403, 'user': 403, 'artist': 200},
+        'post': {None: 403, 'user': 403, 'artist': 201},
+        'delete': {None: 403, 'user': 403, 'artist': 204},
+    }
+
+
+class ReadOnlyModelViewSetMixin:
     methods_behavior = {
         'list': 200,
         'get': 200,


### PR DESCRIPTION
Bonjour,

Voici un quatrième lot de tests pour l'API v2. Il a pris un peu plus de temps que prévu à accoucher, et n'est pas encore absolument complet, notamment:
- Certains modèles de l'appli `production` semblent read-only mais il doit probablement me manquer quelque chose pour accéder en écriture. Je n'ai pas encore sérieusement investigué cet aspect.
- Les filtres ne sont pas encore testés.
- Quelques cas particulier dans `people` ne sont pas testés.

Sinon ça soulève un peu de code mort et quelques interrogations sous forme de `FIXME`.

J'ai réformé/simplifié un peu de code de test de l'API v1, en introduisant un peu plus d'implicite (cf `target`, `requestor`). Ça évite trop de répétitions.